### PR TITLE
Fixing the bug when the value contains "." dots

### DIFF
--- a/import-tags.sh
+++ b/import-tags.sh
@@ -16,7 +16,7 @@ tags_to_env () {
     for key in $(echo $tags | /usr/bin/jq -r ".[][].Key"); do
         value=$(echo $tags | /usr/bin/jq -r ".[][] | select(.Key==\"$key\") | .Value")
         key=$(echo $key | /usr/bin/tr '-' '_' | /usr/bin/tr '[:lower:]' '[:upper:]')
-        export $key=$value
+        export $key="$value"
     done
 }
 


### PR DESCRIPTION
Depending on the value of $value, the script will fail... Values with "." dot will be interpreted differently. Therefore, the value must be enclosed with double-quotes!

I found this bug while trying to export a tag with the value "007.agent" and it failed.
